### PR TITLE
Feature: Use type UUID for ID of Messages to ensure (state of the art…

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/Workiva/go-datastructures v1.0.52
 	github.com/fortytw2/leaktest v1.3.0
+	github.com/google/uuid v1.1.2
 	github.com/houseofcat/turbocookedrabbit/v2 v2.0.8
 	github.com/json-iterator/go v1.1.10
 	github.com/klauspost/compress v1.11.0

--- a/v2/pkg/tcr/json.go
+++ b/v2/pkg/tcr/json.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 )
 
@@ -116,7 +117,7 @@ func CreatePayload(
 // CreateWrappedPayload wraps your data in a plaintext wrapper called ModdedLetter and performs the selected modifications to data.
 func CreateWrappedPayload(
 	input interface{},
-	letterID uint64,
+	letterID uuid.UUID,
 	metadata string,
 	compression *CompressionConfig,
 	encryption *EncryptionConfig) ([]byte, error) {

--- a/v2/pkg/tcr/letter.go
+++ b/v2/pkg/tcr/letter.go
@@ -1,10 +1,13 @@
 package tcr
 
-import "github.com/streadway/amqp"
+import (
+	"github.com/google/uuid"
+	"github.com/streadway/amqp"
+)
 
 // Letter contains the message body and address of where things are going.
 type Letter struct {
-	LetterID   uint64
+	LetterID   uuid.UUID
 	RetryCount uint32
 	Body       []byte
 	Envelope   *Envelope
@@ -23,7 +26,7 @@ type Envelope struct {
 
 // WrappedBody is to go inside a Letter struct with indications of the body of data being modified (ex., compressed).
 type WrappedBody struct {
-	LetterID       uint64      `json:"LetterID"`
+	LetterID       uuid.UUID   `json:"LetterID"`
 	Body           *ModdedBody `json:"Body"`
 	LetterMetadata string      `json:"LetterMetadata"`
 }

--- a/v2/pkg/tcr/letters.go
+++ b/v2/pkg/tcr/letters.go
@@ -2,9 +2,9 @@ package tcr
 
 import (
 	"math/rand"
-	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/streadway/amqp"
 )
@@ -14,7 +14,7 @@ var mockRandomSource = rand.NewSource(time.Now().UnixNano())
 var mockRandom = rand.New(mockRandomSource)
 
 // CreateLetter creates a simple letter for publishing.
-func CreateLetter(letterID uint64, exchangeName string, queueName string, body []byte) *Letter {
+func CreateLetter(letterID uuid.UUID, exchangeName string, queueName string, body []byte) *Letter {
 
 	envelope := &Envelope{
 		Exchange:    exchangeName,
@@ -31,10 +31,10 @@ func CreateLetter(letterID uint64, exchangeName string, queueName string, body [
 }
 
 // CreateMockLetter creates a mock letter for publishing.
-func CreateMockLetter(letterID uint64, exchangeName string, queueName string, body []byte) *Letter {
+func CreateMockLetter(letterID uuid.UUID, exchangeName string, queueName string, body []byte) *Letter {
 
-	if letterID == 0 {
-		letterID = uint64(1)
+	if letterID == uuid.Nil {
+		letterID = uuid.New()
 	}
 
 	if body == nil { //   h   e   l   l   o       w   o   r   l   d
@@ -59,9 +59,6 @@ func CreateMockLetter(letterID uint64, exchangeName string, queueName string, bo
 // CreateMockRandomLetter creates a mock letter for publishing with random sizes and random Ids.
 func CreateMockRandomLetter(queueName string) *Letter {
 
-	letterID := atomic.LoadUint64(&globalLetterID)
-	atomic.AddUint64(&globalLetterID, 1)
-
 	body := RandomBytes(mockRandom.Intn(randomMax-randomMin) + randomMin)
 
 	envelope := &Envelope{
@@ -75,7 +72,7 @@ func CreateMockRandomLetter(queueName string) *Letter {
 	envelope.Headers["x-tcr-testheader"] = "HelloWorldHeader"
 
 	return &Letter{
-		LetterID:   letterID,
+		LetterID:   uuid.New(),
 		RetryCount: uint32(0),
 		Body:       body,
 		Envelope:   envelope,
@@ -85,8 +82,7 @@ func CreateMockRandomLetter(queueName string) *Letter {
 // CreateMockRandomWrappedBodyLetter creates a mock Letter for publishing with random sizes and random Ids.
 func CreateMockRandomWrappedBodyLetter(queueName string) *Letter {
 
-	letterID := atomic.LoadUint64(&globalLetterID)
-	atomic.AddUint64(&globalLetterID, 1)
+	letterID := uuid.New()
 
 	body := RandomBytes(mockRandom.Intn(randomMax-randomMin) + randomMin)
 

--- a/v2/pkg/tcr/message.go
+++ b/v2/pkg/tcr/message.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/streadway/amqp"
 )
 
 // PublishReceipt is a way to monitor publishing success and to initiate a retry when using async publishing.
 type PublishReceipt struct {
-	LetterID     uint64
+	LetterID     uuid.UUID
 	FailedLetter *Letter
 	Success      bool
 	Error        error

--- a/v2/pkg/tcr/rabbitservice.go
+++ b/v2/pkg/tcr/rabbitservice.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/streadway/amqp"
 )
 
@@ -131,8 +131,7 @@ func (rs *RabbitService) PublishWithConfirmation(
 		return errors.New("can't have a nil body or an empty exchangename with empty routing key")
 	}
 
-	currentCount := atomic.LoadUint64(&rs.letterCount)
-	atomic.AddUint64(&rs.letterCount, 1)
+	currentCount := uuid.New()
 
 	var data []byte
 	var err error
@@ -184,8 +183,7 @@ func (rs *RabbitService) Publish(
 		return errors.New("can't have a nil input or an empty exchangename with empty routing key")
 	}
 
-	currentCount := atomic.LoadUint64(&rs.letterCount)
-	atomic.AddUint64(&rs.letterCount, 1)
+	currentCount := uuid.New()
 
 	var data []byte
 	var err error
@@ -233,8 +231,7 @@ func (rs *RabbitService) PublishData(
 		return errors.New("can't have a nil input or an empty exchangename with empty routing key")
 	}
 
-	currentCount := atomic.LoadUint64(&rs.letterCount)
-	atomic.AddUint64(&rs.letterCount, 1)
+	currentCount := uuid.New()
 
 	rs.Publisher.Publish(
 		&Letter{
@@ -262,8 +259,7 @@ func (rs *RabbitService) PublishLetter(letter *Letter) error {
 		return errors.New("unable to publish as service shutdown triggered")
 	}
 
-	currentCount := atomic.LoadUint64(&rs.letterCount)
-	atomic.AddUint64(&rs.letterCount, 1)
+	currentCount := uuid.New()
 
 	letter.LetterID = currentCount
 
@@ -280,8 +276,7 @@ func (rs *RabbitService) QueueLetter(letter *Letter) error {
 		return errors.New("unable to queue letter as service shutdown triggered")
 	}
 
-	currentCount := atomic.LoadUint64(&rs.letterCount)
-	atomic.AddUint64(&rs.letterCount, 1)
+	currentCount := uuid.New()
 
 	letter.LetterID = currentCount
 

--- a/v2/tests/main_bench_test.go
+++ b/v2/tests/main_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	cmap "github.com/orcaman/concurrent-map"
 	"github.com/stretchr/testify/assert"
 
@@ -38,13 +39,10 @@ func BenchmarkPublishAndConsumeMany(b *testing.B) {
 
 	publisher.StartAutoPublishing()
 
-	counter := uint64(0)
-
 	go func() {
 		for i := 0; i < messageCount; i++ {
 			letter := tcr.CreateMockRandomLetter("TcrTestQueue")
-			letter.LetterID = counter
-			counter++
+			letter.LetterID = uuid.New()
 
 			publisher.QueueLetter(letter)
 		}

--- a/v2/tests/main_publisher_test.go
+++ b/v2/tests/main_publisher_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/fortytw2/leaktest"
+	"github.com/google/uuid"
 	"github.com/stoex/turbocookedrabbit/v2/pkg/tcr"
 	"github.com/streadway/amqp"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestBasicPublish(t *testing.T) {
 	letters := make([]*tcr.Letter, messageCount)
 
 	for i := 0; i < messageCount; i++ {
-		letters[i] = tcr.CreateMockLetter(uint64(i), "", fmt.Sprintf("TestQueue-%d", i%10), nil)
+		letters[i] = tcr.CreateMockLetter(uuid.New(), "", fmt.Sprintf("TestQueue-%d", i%10), nil)
 	}
 
 	elapsed := time.Since(timeStart)


### PR DESCRIPTION
…) uniqueness and avoid

collisions that are much likely to happen if using a uint64 based PRNG.